### PR TITLE
fixed a bug in SessionHandle->get() and added a unit test for CryptMsg

### DIFF
--- a/src/Controller/Enter.php
+++ b/src/Controller/Enter.php
@@ -8,6 +8,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use SimpleMVC\Helper\SessionHandle;
 use SimpleMVC\Helper\LoginAction;
 
+use SimpleMVC\Helper\CryptMsg;
+
 class Enter implements ControllerInterface
 {
     protected $plates;
@@ -23,8 +25,7 @@ class Enter implements ControllerInterface
     {
         // exec login logics
         $username = addslashes(filter_var($_POST['user'], FILTER_SANITIZE_STRING));//$_POST['user'];
-       /* echo $username;
-        die();*/
+        echo $username;
         $password = $_POST['pwd'];
 
         if ($this->login->loginUser($username, $password)) {

--- a/src/Helper/CryptMsg.php
+++ b/src/Helper/CryptMsg.php
@@ -27,7 +27,7 @@ class CryptMsg {
             self::$key = base64_decode(self::$key);
         }
 
-        self::nonce();
+        // self::nonce();
         return $this;
     }
 

--- a/src/Helper/SessionHandle.php
+++ b/src/Helper/SessionHandle.php
@@ -35,12 +35,12 @@ class SessionHandle {
 
     public function set(string $key, string $value) {
         $value = $this->crypt->encrypt($value, $this->crypt->nonce());
-        $_SESSION[$key] = htmlspecialchars($value);
+        $_SESSION[$key] = $value;
     }
 
     public function get(string $key) :string{
         $value = $_SESSION[$key];
-        return htmlspecialchars($this->crypt->decrypt($value, $this->crypt->nonce()));
+        return $this->crypt->decrypt($value, $this->crypt->nonce());
     }
 
     public function unset(string $key) {

--- a/test/Helpers/Crypt.php
+++ b/test/Helpers/Crypt.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace SimpleMVC\Test\Helpers;
+
+use PHPUnit\Framework\TestCase;
+use SimpleMVC\Helper\CryptMsg;
+
+class Crypt extends TestCase {
+
+    public function setUp(): void
+    {
+        $this->crypt = CryptMsg::instance();
+        $this->nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $this->msg = 'A super secret message';
+    }
+
+    public function testAreCryptEncryptedStringEquals() :void {
+        $encrypted = $this->crypt->encrypt($this->msg, $this->nonce);
+        $this->assertEquals(
+            $this->msg, $this->crypt->decrypt($encrypted, $this->nonce)
+        );
+    }
+}


### PR DESCRIPTION
Solved a bug that prevented return of encrypted data from session and added a unit test for CryptMsg to check if encryption/decryption were correctly handled.